### PR TITLE
content introtext

### DIFF
--- a/libraries/eshiol/J2xml/Table/Content.php
+++ b/libraries/eshiol/J2xml/Table/Content.php
@@ -673,6 +673,14 @@ class Content extends Table
 			}
 			unset($data['association']);
 		}
+
+		if ($version->isCompatible('4'))
+		{
+			if (! isset($data['introtext']))
+			{
+				$data['introtext'] = '';
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue #41  .

### Summary of Changes
J2XML 3.9 can import articles without introtext.


### Testing Instructions
Create an article without introtext. The article must start with the tag read more.
Export the article.
Import the article.


### Expected result
Article [135 -> 133] Article with empty introtext successfully imported.


### Actual result
Article [135] Article with empty introtext not imported with the following error: Field 'introtext' doesn't have a default value


### Documentation Changes Required

