### PR TITLE
Fix users export if fields are set

### DIFF
--- a/libraries/eshiol/J2xml/Table/User.php
+++ b/libraries/eshiol/J2xml/Table/User.php
@@ -544,6 +544,7 @@ class User extends Table
 			}
 		}
 
+		$version = new \JVersion();
 		if (isset($options['fields']) && $options['fields'] && $version->isCompatible('3.7'))
 		{
 			if ($version->isCompatible('4'))


### PR DESCRIPTION
Users are not exported if the option Export users / fields is set.

### Summary of Changes



### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

