### PR TITLE
fix: set hits

### DIFF
--- a/libraries/eshiol/J2xml/Table/Content.php
+++ b/libraries/eshiol/J2xml/Table/Content.php
@@ -405,6 +405,9 @@ class Content extends Table
 					{
 						if ($version->isCompatible('4'))
 						{
+							// fix hits
+							$table->save($data);
+
 							$item = $table->getItem();
 						}
 						else


### PR DESCRIPTION
### Summary of Changes
The articles hits field is set correctly.


### Testing Instructions
Import an article.


### Expected result
The hits field of the articles is set correctly


### Actual result
The hits field is set correctly if the article already exists. If the article is new the field is set to zero.


### Documentation Changes Required

