### PR TITLE
PHP 8.2: Dynamic Properties are deprecated - J2xml\Importer

### DIFF
--- a/libraries/eshiol/J2xml/Importer.php
+++ b/libraries/eshiol/J2xml/Importer.php
@@ -69,6 +69,8 @@ class Importer
 
 	protected $_nullDate;
 
+	protected $_user;
+
 	protected $_user_id;
 
 	protected $_now;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes



### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

