### PR TITLE
Joomla 5.0.0 PHP 8.2 Import

### DIFF
--- a/administrator/components/com_j2xml/models/import.php
+++ b/administrator/components/com_j2xml/models/import.php
@@ -121,10 +121,12 @@ class J2xmlModelImport extends JModelForm
 
 		JLog::add(new JLogEntry('package: ' . print_r($package, true), JLog::DEBUG, 'com_j2xml'));
 
-		if (!($data = implode(gzfile($package['packagefile'])))) {
-			$data = file_get_contents($package['packagefile']);
+		$data = new \stdClass();
+
+		if (!($data->content = implode(gzfile($package['packagefile'])))) {
+			$data->content = file_get_contents($package['packagefile']);
 		}
-		JLog::add(new JLogEntry('data: ' . $data, JLog::DEBUG, 'com_j2xml'));
+		JLog::add(new JLogEntry('data: ' . $data->content, JLog::DEBUG, 'com_j2xml'));
 
 		$jform = JFactory::getApplication()->input->post->get('jform', array(), 'array');
 
@@ -174,13 +176,13 @@ class J2xmlModelImport extends JModelForm
 			return false;
 		}
 
-		$data = strstr($data, '<?xml version="1.0" ');
+		$data->content = strstr($data->content, '<?xml version="1.0" ');
 		if (!defined('LIBXML_PARSEHUGE'))
 		{
 			define(LIBXML_PARSEHUGE, 524288);
 		}
 
-		$xml = simplexml_load_string($data, 'SimpleXMLElement', LIBXML_PARSEHUGE);
+		$xml = simplexml_load_string($data->content, 'SimpleXMLElement', LIBXML_PARSEHUGE);
 		if (!$xml)
 		{
 			return;


### PR DESCRIPTION
0  Joomla\CMS\Event\Model\PrepareDataEvent::onSetData(): Argument #1 ($value) must be of type object|array, string given, called in /var/www/html/libraries/src/Event/AbstractEvent.php on line 225

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

