### PR TITLE
Joomla 5.0.0 PHP 8.2 Export

### DIFF
--- a/libraries/eshiol/J2xml/Table/Table.php
+++ b/libraries/eshiol/J2xml/Table/Table.php
@@ -24,7 +24,10 @@ use Joomla\Utilities\ArrayHelper;
 
 \JLoader::import('eshiol.J2xml.Version');
 
-class_alias('\\Joomla\\Database\\DatabaseDriver', 'JDatabaseDriver');
+if (!class_exists('JDatabaseDriver'))
+{
+	class_alias('\\Joomla\\Database\\DatabaseDriver', 'JDatabaseDriver');
+}
 
 /**
  *

--- a/libraries/eshiol/J2xml/Table/Table.php
+++ b/libraries/eshiol/J2xml/Table/Table.php
@@ -24,6 +24,8 @@ use Joomla\Utilities\ArrayHelper;
 
 \JLoader::import('eshiol.J2xml.Version');
 
+class_alias('\\Joomla\\Database\\DatabaseDriver', 'JDatabaseDriver');
+
 /**
  *
  * Table


### PR DESCRIPTION
0 eshiol\J2xml\Table\Content::__construct(): Argument #1 ($db) must be of type JDatabaseDriver, Joomla\Database\Mysqli\MysqliDriver given, called in /var/www/html/libraries/eshiol/J2xml/Table/Content.php on line 704

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

